### PR TITLE
Corrección de la estructura de la extensión

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -5,32 +5,13 @@
         "budgetBreakdown": {
           "budgetClassifications": {
             "type": "array",
-            "origin": {
-              "title": "origin of funding source",
-              "description": "Codelist that allows you to choose an origin of the monetary funding.",
-              "type": [
-                "string",
-                "null"
-              ],
-              "codelist": "originFoundingSource.csv",
-              "openCodelist": false,
-              "enum": [
-                "Recursos fiscales",
-                "Gasto financiado con recursos del BID-BIRF, así como otros financiamientos externos",
-                "Contraparte nacional",
-                "Ingresos Propios",
-                "Financiamientos Internos",
-                "Financiamientos externos",
-                "Recursos federales",
-                "Recursos estatales",
-                "Otros recursos"
-              ]
+            "components": {
+              "type": "array",
+              "name": "The name of the component of this budget line using the [budgetClassificationsComponents](https://github.com/INAImexico/ocds_budgetClasifications_extension/blob/master/codelists/budgetClassificationComponents.csv) codelist.",
+              "level": "The hierarchy level of the component inside a classification.",
+              "id": "ID to identify a specific value of the origin component.",
+              "description": "Descripction of the specific value of the component."
             },
-            "classifications": "Open codelist that allows you to choose a budget clasification.",
-            "level": "ID to identify the hierarchy level for the concept inside a classification.",
-            "levelLabel": "Name of the concept.",
-            "id": "ID to identify a specific value of the origin concept.",
-            "description": "Descripction of the specific value of the concept.",
             "measures": {
               "type": "array",
               "id": "ID to identify the specific accruing moment in which the budget's value will be expressed.",


### PR DESCRIPTION
Se hicieron cambios a la estructura de la extensión para adecuarla a la conformación de la clave presupuestaria en México. El atributo "origin" se eliminó debido a que este valores se pueden especificar en los atributos "id" y "description" dentro del arreglo "components". También se eliminó el atributo "classifications" debido a que repetía la función del atributo "levelLabel" y este último se renombró  por "name". Por último, se cambio la jerarquía de "measures" para evitar que se pusieran estos valores por cada uno de los componentes de la clave presupuestaria y sólo fuera único para cada una de ellas.